### PR TITLE
updated defaults to install current version, added apache vhost config

### DIFF
--- a/inventories/centos7/group_vars/owncloud.yml
+++ b/inventories/centos7/group_vars/owncloud.yml
@@ -1,5 +1,5 @@
 ---
-owncloud_version: "10.3.1"
+owncloud_version: "10.4.1"
 owncloud_fqdn: ubuntu.owncloud.demo
 
 # If you would like to access your ownCloud by IP
@@ -41,4 +41,7 @@ owncloud_log_dateformat: "Y-m-d H:i:s.u"
 
 php_date_timezone: "{{ owncloud_log_timezone }}"
 
+apache_vhosts:
+  - servername: "{{ owncloud_fqdn }}"
+    documentroot: "/var/www/owncloud"
 ...

--- a/inventories/centos7/group_vars/owncloud.yml
+++ b/inventories/centos7/group_vars/owncloud.yml
@@ -43,5 +43,5 @@ php_date_timezone: "{{ owncloud_log_timezone }}"
 
 apache_vhosts:
   - servername: "{{ owncloud_fqdn }}"
-    documentroot: "/var/www/owncloud"
+    documentroot: "{{ owncloud_deploy_path }}"
 ...

--- a/inventories/ubuntu-minimal/group_vars/owncloud.yml
+++ b/inventories/ubuntu-minimal/group_vars/owncloud.yml
@@ -27,5 +27,5 @@ php_date_timezone: "{{ owncloud_log_timezone }}"
 
 apache_vhosts:
   - servername: "{{ owncloud_fqdn }}"
-    documentroot: "/var/www/owncloud"
+    documentroot: "{{ owncloud_deploy_path }}"
 ...

--- a/inventories/ubuntu-minimal/group_vars/owncloud.yml
+++ b/inventories/ubuntu-minimal/group_vars/owncloud.yml
@@ -1,5 +1,5 @@
 ---
-owncloud_version: "10.3.1"
+owncloud_version: "10.4.1"
 owncloud_fqdn: ubuntu.owncloud.demo
 
 # If you would like to access your ownCloud by IP
@@ -25,4 +25,7 @@ owncloud_log_dateformat: "Y-m-d H:i:s.u"
 
 php_date_timezone: "{{ owncloud_log_timezone }}"
 
+apache_vhosts:
+  - servername: "{{ owncloud_fqdn }}"
+    documentroot: "/var/www/owncloud"
 ...

--- a/inventories/vagrant/group_vars/owncloud.yml
+++ b/inventories/vagrant/group_vars/owncloud.yml
@@ -27,5 +27,5 @@ php_date_timezone: "{{ owncloud_log_timezone }}"
 
 apache_vhosts:
   - servername: "{{ owncloud_fqdn }}"
-    documentroot: "/var/www/owncloud"
+    documentroot: "{{ owncloud_deploy_path }}"
 ...

--- a/inventories/vagrant/group_vars/owncloud.yml
+++ b/inventories/vagrant/group_vars/owncloud.yml
@@ -1,5 +1,5 @@
 ---
-owncloud_version: "10.3.1"
+owncloud_version: "10.4.1"
 owncloud_fqdn: vagrant.owncloud.demo
 
 # If you would like to access your ownCloud by IP
@@ -25,4 +25,7 @@ owncloud_log_dateformat: "Y-m-d H:i:s.u"
 
 php_date_timezone: "{{ owncloud_log_timezone }}"
 
+apache_vhosts:
+  - servername: "{{ owncloud_fqdn }}"
+    documentroot: "/var/www/owncloud"
 ...


### PR DESCRIPTION
- Current ownCloud version is 10.4.1 so we should install that.
- apache_vhosts server name default is "cloud.owncloud.demo", so it should be overwritten in a deployment