### PR TITLE
Add centos8 inventory

### DIFF
--- a/inventories/centos8/group_vars/database.yml
+++ b/inventories/centos8/group_vars/database.yml
@@ -1,0 +1,18 @@
+---
+mariadb_root_password: root
+
+mariadb_port: "3306"
+mariadb_bind_address: "127.0.0.0"
+
+mariadb_databases:
+  - name: owncloud
+    collation: utf8mb4_bin
+    encoding: utf8mb4
+
+mariadb_users:
+  - name: owncloud
+    host: localhost
+    password: owncloud
+    priv: "owncloud.*:ALL"
+
+...

--- a/inventories/centos8/group_vars/owncloud.yml
+++ b/inventories/centos8/group_vars/owncloud.yml
@@ -1,0 +1,53 @@
+---
+owncloud_version: "10.6.0"
+owncloud_fqdn: ubuntu.owncloud.demo
+
+# If you would like to access your ownCloud by IP
+# you can add it to trusted domains.
+owncloud_trusted_domains:
+  - "{{ owncloud_fqdn }}"
+  - "{{ ansible_default_ipv4.address }}"
+
+# You can also adjust the default ownCloud user.
+# For security reasons you should set a strong password!
+owncloud_admin_username: admin
+owncloud_admin_password: owncloud
+
+owncloud_db_name: owncloud
+owncloud_db_user: owncloud
+owncloud_db_password: owncloud
+
+owncloud_web_default_language: "de_DE"
+
+owncloud_deploy_path: /var/www/owncloud
+owncloud_src_path: "/usr/local/src/{{ owncloud_system_user }}"
+owncloud_data_path: "{{ owncloud_src_path }}/data"
+owncloud_config_path: "{{ owncloud_src_path }}/config"
+
+owncloud_apps:
+  - name: activity
+  - name: contacts
+  - name: twofactor_totp
+  - name: files_mediaviewer
+  - name: password_policy
+  - name: brute_force_protection
+
+# Only supported for ownCloud >= 10.2.1
+owncloud_encryption_enabled: True
+owncloud_encryption_force_encrypt_all: False
+
+owncloud_log_timezone: "Etc/UTC"
+owncloud_log_dateformat: "Y-m-d H:i:s.u"
+
+php_default_version: "7.3"
+php_date_timezone: "{{ owncloud_log_timezone }}"
+php_packages_extra:
+  - gcc
+  - make
+
+apache_packages_extra: []
+
+apache_vhosts:
+  - servername: "{{ owncloud_fqdn }}"
+    documentroot: "{{ owncloud_deploy_path }}"
+...

--- a/inventories/centos8/group_vars/redis.yml
+++ b/inventories/centos8/group_vars/redis.yml
@@ -1,0 +1,5 @@
+---
+redis_port: "6379"
+redis_bind_interface: "127.0.0.1"
+
+...

--- a/inventories/centos8/hosts
+++ b/inventories/centos8/hosts
@@ -1,0 +1,8 @@
+[database]
+db1
+
+[redis]
+redis1
+
+[owncloud]
+owncloud1


### PR DESCRIPTION
On Centos8, it is necessary to remove `centos-release-scl` from https://github.com/owncloud-ansible/playground/blob/10ccd80d76e73ede5174338a6f19bd465bce019d/inventories/centos7/group_vars/owncloud.yml#L45 and https://github.com/owncloud-ansible/playground/blob/10ccd80d76e73ede5174338a6f19bd465bce019d/inventories/centos7/group_vars/owncloud.yml#L50 to make the playbook run successful.

https://github.com/UnivaCorporation/tortuga/issues/624#issuecomment-606266437

Is there a better way to implement it, e.g. with a version variable for a version independent CentOS inventory?