### PR TITLE
Set variables for mariadb database, port and host

### DIFF
--- a/inventories/suse/group_vars/database.yml
+++ b/inventories/suse/group_vars/database.yml
@@ -3,6 +3,14 @@
 # for the owncloud DB and root user!
 mariadb_root_password: root
 
+mariadb_port: "3306"
+mariadb_bind_address: "127.0.0.0"
+
+mariadb_databases:
+  - name: owncloud
+    collation: utf8mb4_bin
+    encoding: utf8mb4
+
 mariadb_users:
   - name: owncloud
     host: localhost

--- a/inventories/ubuntu-minimal/group_vars/database.yml
+++ b/inventories/ubuntu-minimal/group_vars/database.yml
@@ -3,6 +3,14 @@
 # for the owncloud DB and root user!
 mariadb_root_password: root
 
+mariadb_port: "3306"
+mariadb_bind_address: "127.0.0.0"
+
+mariadb_databases:
+  - name: owncloud
+    collation: utf8mb4_bin
+    encoding: utf8mb4
+
 mariadb_users:
   - name: owncloud
     host: localhost


### PR DESCRIPTION
Ubuntu inventory haven't had the variables for 
- database
- host
- port
set explicitly like it is done in other inventories e.g. centos

To avoid confusion by implicit defaulting and uniform it over the inventories, I added the variables.