### PR TITLE
README update to indicate required Ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository is intended as an entry point into an ownCloud deployment with A
 
 For more details, please have a look at the [documentation](https://owncloud-ansible.github.io/).
 
+Current required Ansible version is minimum 2.10 or higher.
+
+Install a newer Ansible version like:
+
+`python3 -m venv ~/ansible && source ~/ansible/bin/activate && pip3 install ansible`
+
 ## License
 
 This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
README update to indicate that the default Ansible installation on CentOS7/Ubuntu 20.04 is not working and it must be manually updated before using the playbook