### PR TITLE
DOC and README update

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -4,6 +4,12 @@ title: Setup
 
 These docs are work in progress so they will be incomplete. 
 
+Current required Ansible version is minimum 2.10 or higher on all Linux distribution.
+
+Install a newer Ansible version like:
+
+`python3 -m venv ~/ansible && source ~/ansible/bin/activate && pip3 install ansible`
+
 ## CentOS 7 
 ### Requirements
 These are the packages / repositories that need to be enabled / installed before the first playbook execution.


### PR DESCRIPTION
DOC and README update to indicate that the default Ansible installation on CentOS7/Ubuntu 20.04, etc. is not working and it must be manually updated before using the playbook