### PR TITLE
Fix for Vagrant deployments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.require_version ">= 2.0.0"
 
 Vagrant.configure(2) do |config|
 
- config.vm.box = "ubuntu/bionic64"
+ config.vm.box = "ubuntu/focal64"
  config.vm.network 'private_network', ip: '172.30.1.2'
  config.vm.provision "ansible_local" do |ansible|
    ansible.verbose = "v"

--- a/inventories/vagrant/group_vars/owncloud.yml
+++ b/inventories/vagrant/group_vars/owncloud.yml
@@ -1,6 +1,7 @@
 ---
-owncloud_version: "10.4.1"
+owncloud_version: "10.9.1"
 owncloud_fqdn: vagrant.owncloud.demo
+owncloud_deploy_path: /var/www/owncloud
 
 # If you would like to access your ownCloud by IP
 # you can add it to trusted domains.


### PR DESCRIPTION
The Vagrant deployments didn't work due to some issues with the Ansible scripts and the old Ansible version in Ubuntu Bionic. So the Ubuntu version was increase as well as the ownCloud version was increased to the most recent one. Furthermore one missing Ansible variable which broke deployments via Vagrant was added.
